### PR TITLE
Add some basic type class instances for `OpenMode` and `OpenFileFlags`.

### DIFF
--- a/System/Posix/IO/Common.hsc
+++ b/System/Posix/IO/Common.hsc
@@ -129,6 +129,7 @@ stdOutput  = Fd (#const STDOUT_FILENO)
 stdError   = Fd (#const STDERR_FILENO)
 
 data OpenMode = ReadOnly | WriteOnly | ReadWrite
+              deriving (Show, Eq, Ord)
 
 -- |Correspond to some of the int flags from C's fcntl.h.
 data OpenFileFlags =
@@ -156,6 +157,7 @@ data OpenFileFlags =
                                  --
                                  -- @since 2.8.0.0
  }
+ deriving (Show, Eq, Ord)
 
 
 -- | Default values for the 'OpenFileFlags' type.


### PR DESCRIPTION
I've written a few different programs that provide orphan instances for these types, and I think that adding some basic derived instances should be uncontroversial.

Closes #75.